### PR TITLE
Fixed an issue with the remove method of hotkeys.service

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,8 @@ npm-debug.log
 # *.js
 # *.map
 # *.d.ts
+*.ts
+!*.d.ts
 
 # JetBrains
 .idea

--- a/.npmignore
+++ b/.npmignore
@@ -7,8 +7,6 @@ npm-debug.log
 # *.js
 # *.map
 # *.d.ts
-*.ts
-!*.d.ts
 
 # JetBrains
 .idea

--- a/src/directives/hotkeys.directive.ts
+++ b/src/directives/hotkeys.directive.ts
@@ -1,7 +1,7 @@
 import {Directive, Input, OnInit, OnDestroy, ElementRef} from '@angular/core';
 import {Hotkey} from '../models/hotkey.model';
 import {HotkeysService} from '../services/hotkeys.service';
-import 'mousetrap';
+import {ExtendedKeyboardEvent, MousetrapInstance} from 'mousetrap';
 
 @Directive({
     selector : '[hotkeys]',

--- a/src/directives/hotkeys.directive.ts
+++ b/src/directives/hotkeys.directive.ts
@@ -1,18 +1,18 @@
 import {Directive, Input, OnInit, OnDestroy, ElementRef} from '@angular/core';
 import {Hotkey} from '../models/hotkey.model';
 import {HotkeysService} from '../services/hotkeys.service';
-import {ExtendedKeyboardEvent, MousetrapInstance} from 'mousetrap';
+import 'mousetrap';
 
 @Directive({
     selector : '[hotkeys]',
     providers : [HotkeysService]
 })
 export class Hotkeys implements OnInit, OnDestroy {
-    @Input('hotkeys') hotkeysInput: Array<{[combo: string]: (event: KeyboardEvent, combo: string) => ExtendedKeyboardEvent}>;
+    @Input('hotkeys') private hotkeysInput: Array<{[combo: string]: (event: KeyboardEvent, combo: string) => ExtendedKeyboardEvent}>;
 
-    mousetrap: MousetrapInstance;
-    hotkeys: Hotkey[] = [];
-    oldHotkeys: Hotkey[] = [];
+    private mousetrap: MousetrapInstance;
+    private hotkeys: Hotkey[] = [];
+    private oldHotkeys: Hotkey[] = [];
 
     constructor(private _hotkeysService: HotkeysService, private _elementRef: ElementRef) {
         this.mousetrap = new Mousetrap(this._elementRef.nativeElement); // Bind hotkeys to the current element (and any children)

--- a/src/models/hotkey.model.ts
+++ b/src/models/hotkey.model.ts
@@ -1,3 +1,5 @@
+import {ExtendedKeyboardEvent} from 'mousetrap';
+
 export class Hotkey {
     _formatted: string[];
 

--- a/src/models/hotkey.model.ts
+++ b/src/models/hotkey.model.ts
@@ -1,4 +1,4 @@
-import {ExtendedKeyboardEvent} from 'mousetrap';
+import 'mousetrap';
 
 export class Hotkey {
     _formatted: string[];
@@ -13,7 +13,7 @@ export class Hotkey {
      * @param {array}    allowIn     an array of tag names to allow this combo in ('INPUT', 'SELECT', and/or 'TEXTAREA')
      * @param {boolean}  persistent  if true, the binding is preserved upon route changes
      */
-    constructor(public combo: string | string[], public callback: (event: KeyboardEvent, combo: string) => ExtendedKeyboardEvent,
+    constructor(public combo: string | string[], public callback: (event: KeyboardEvent, combo: string) => any,
                 public allowIn?: string[], public description?: string | Function, public action?: string,
                 public persistent?: boolean) {
         this.combo = (Array.isArray(combo) ? combo : [<string>combo]);

--- a/src/services/hotkeys.service.ts
+++ b/src/services/hotkeys.service.ts
@@ -70,7 +70,7 @@ export class HotkeysService {
         }
         let index = this.findHotkey(<Hotkey>hotkey);
         if(index > -1) {
-            this.hotkeys.slice(index, 1);
+            this.hotkeys.splice(index, 1);
             Mousetrap.unbind((<Hotkey>hotkey).combo);
             return hotkey;
         }


### PR DESCRIPTION
- replaced slice by splice
- removed the .ts when publishing with npm
- When I use the library,  I have this error: 
error TS4063: Parameter 'callback' of constructor from exported class has or is using private name 'ExtendedKeyboardEvent'

I think this is because the ExtendedKeyboardEvent is not exported. To solve the error, I use "any". I don't have a better solution for now.

Thanks for the library,
Stephane