### PR TITLE
Fix broken change detection when using HotkeysService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/*
 npm-debug.log
 
 # TypeScript
+typings
 *.js
 *.map
 *.d.ts

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "reflect-metadata": "^0.1.3",
         "rxjs": "5.0.0-beta.6",
         "tslint": "^3.4.0",
-        "typings": "^0.6.6",
+        "typings": "^1.3.1",
         "zone.js": "^0.6.12"
     },
     "peerDependencies": {

--- a/src/services/hotkeys.service.ts
+++ b/src/services/hotkeys.service.ts
@@ -6,6 +6,7 @@ import 'mousetrap';
 export class HotkeysService {
     hotkeys: Hotkey[] = [];
     pausedHotkeys: Hotkey[] = [];
+    mousetrap: MousetrapInstance;
 
     private _preventIn = ['INPUT', 'SELECT', 'TEXTAREA'];
 
@@ -17,6 +18,7 @@ export class HotkeysService {
             }
             return (element.contentEditable && element.contentEditable == 'true');
         };
+        this.mousetrap = new (<any>Mousetrap)();
     }
 
     add(hotkey: Hotkey | Hotkey[]): Hotkey | Hotkey[] {
@@ -29,7 +31,7 @@ export class HotkeysService {
         }
         this.remove(hotkey);
         this.hotkeys.push(<Hotkey>hotkey);
-        Mousetrap.bind((<Hotkey>hotkey).combo, (event: KeyboardEvent, combo: string) => {
+        this.mousetrap.bind((<Hotkey>hotkey).combo, (event: KeyboardEvent, combo: string) => {
             let shouldExecute = true;
 
             // if the callback is executed directly `hotkey.get('w').callback()`
@@ -71,7 +73,7 @@ export class HotkeysService {
         let index = this.findHotkey(<Hotkey>hotkey);
         if(index > -1) {
             this.hotkeys.splice(index, 1);
-            Mousetrap.unbind((<Hotkey>hotkey).combo);
+            this.mousetrap.unbind((<Hotkey>hotkey).combo);
             return hotkey;
         }
         return null;
@@ -131,7 +133,7 @@ export class HotkeysService {
     }
 
     reset() {
-        Mousetrap.reset();
+        this.mousetrap.reset();
     }
 
     private findHotkey(hotkey: Hotkey): number {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "declaration": true
   },
   "files": [
-    "typings/main.d.ts",
+    "typings/index.d.ts",
     "angular2-hotkeys.ts"
   ],
   "exclude": [

--- a/typings.json
+++ b/typings.json
@@ -1,10 +1,9 @@
 {
-    "ambientDependencies": {
-        "core-js": "github:DefinitelyTyped/DefinitelyTyped/core-js/core-js.d.ts#c777572e8532c4d358306fe4c0e17a533f940b04",
-        "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#26c98c8a9530c44f8c801ccc3b2057e2101187ee",
+    "globalDependencies": {
+        "core-js": "registry:dt/core-js#0.0.0+20160602141332",
+        "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
         "mousetrap": "registry:dt/mousetrap#1.5.0+20160501152135",
-        "ng2": "github:gdi2290/typings-ng2/ng2.d.ts#32998ff5584c0eab0cd9dc7704abb1c5c450701c",
-        "require": "github:DefinitelyTyped/DefinitelyTyped/requirejs/require.d.ts#853544cb7068af64bdb10ef1ae0c54d3aa3a80f6",
-        "zone.js": "github:DefinitelyTyped/DefinitelyTyped/zone.js/zone.js.d.ts#b923a5aaf013ac84c566f27ba6b5843211981c7a"
+        "require": "registry:dt/require#2.1.20+20160316155526",
+        "zone.js": "registry:dt/zone.js#0.0.0+20160316155526"
     }
 }


### PR DESCRIPTION
Using HotkeysService in my application to add hotkeys was not working with change detection.  

Per http://stackoverflow.com/questions/34592857/view-is-not-updated-on-change-in-angular2 I have updated to enclose the Mousetrap instance in the service's ngZone context.  The Mousetrap type definitions are incorrect and this is valid.

