### PR TITLE
Remove console log messages

### DIFF
--- a/src/directives/hotkeys.directive.ts
+++ b/src/directives/hotkeys.directive.ts
@@ -16,8 +16,6 @@ export class Hotkeys implements OnInit, OnDestroy {
 
     constructor(private _hotkeysService: HotkeysService, private _elementRef: ElementRef) {
         this.mousetrap = new Mousetrap(this._elementRef.nativeElement); // Bind hotkeys to the current element (and any children)
-        console.log('Created hotkey instance');
-        console.dir(this.mousetrap);
     }
 
     ngOnInit() {


### PR DESCRIPTION
The hotkeys directive has some console.log messages that clutter up the console.