### PR TITLE
Cheatsheet

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,9 +59,41 @@ For more information on what hotkeys can be used, check out <https://craig.is/ki
 This library is a work in progress and any issues/pull-requests are welcomed!
 Based off of the [angular-hotkeys library](https://github.com/chieffancypants/angular-hotkeys)
 
+## Cheat Sheet
+
+To enable the cheat sheet, simply add `<hotkeys-cheatsheet></hotkeys-cheatsheet>` to your top level component template.
+The `HotkeysService` will automatically register the `?` key combo to toggle the cheat sheet.
+
+### Cheat Sheet Customization
+
+1. You can now pass in custom options in `HotkeysModule.forRoot(options: IHotkeyOptions)`.
+
+```typescript
+export interface IHotkeyOptions {
+  /**
+   * Disable the cheat sheet popover dialog? Default: false
+   */
+  disableCheatSheet?: boolean;
+  /**
+   * Key combination to trigger the cheat sheet. Default: '?'
+   */
+  cheatSheetHotkey?: string;
+  /**
+   * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'
+   */
+  cheatSheetDescription?: string;
+};
+```
+
+2. You can also customize the title of the cheat sheet component.
+
+```html
+<hotkeys-cheatsheet title="Hotkeys Rock!"></hotkeys-cheatsheet>
+<!-- Default: 'Keyboard Shortcuts:' -->
+```
+
 ## TODO
-1. Automatically generate cheatsheet
-2. Create unit and E2E tests
+1. Create unit and E2E tests
 
 ## Development
 

--- a/angular2-hotkeys.ts
+++ b/angular2-hotkeys.ts
@@ -1,9 +1,12 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import { HotkeyOptions, IHotkeyOptions } from './src/models/hotkey.options';
+import { CheatSheetComponent } from './src/directives/cheatsheet.component';
+import { ModuleWithProviders, NgModule, OpaqueToken } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {Hotkeys} from './src/directives/hotkeys.directive';
 import {HotkeysService} from './src/services/hotkeys.service';
 
 
+export * from './src/directives/cheatsheet.component';
 export * from './src/directives/hotkeys.directive';
 export * from './src/services/hotkeys.service';
 export * from './src/models/hotkey.model';
@@ -14,14 +17,17 @@ export interface ExtendedKeyboardEvent extends KeyboardEvent {
 
 @NgModule({
     imports : [CommonModule],
-    exports : [Hotkeys],
-    declarations : [Hotkeys]
+    exports : [Hotkeys, CheatSheetComponent],
+    declarations : [Hotkeys, CheatSheetComponent]
 })
 export class HotkeyModule {
-    static forRoot(): ModuleWithProviders {
+    static forRoot(options: IHotkeyOptions = {}): ModuleWithProviders {
         return {
             ngModule : HotkeyModule,
-            providers : [HotkeysService]
+            providers : [
+                HotkeysService,
+                { provide: HotkeyOptions, useValue: options }
+            ]
         };
     }
 }

--- a/src/directives/cheatsheet.component.ts
+++ b/src/directives/cheatsheet.component.ts
@@ -1,0 +1,149 @@
+import { Hotkey } from './../models/hotkey.model';
+import { Subscription } from 'rxjs/Subscription';
+import { HotkeysService } from './../services/hotkeys.service';
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
+
+@Component({
+  selector: 'hotkeys-cheatsheet',
+  styles: [`
+.cfp-hotkeys-container {
+  display: table !important;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  color: #333;
+  font-size: 1em;
+  background-color: rgba(255,255,255,0.9);
+}
+
+.cfp-hotkeys-container.fade {
+  z-index: -1024;
+  visibility: hidden;
+  opacity: 0;
+  -webkit-transition: opacity 0.15s linear;
+  -moz-transition: opacity 0.15s linear;
+  -o-transition: opacity 0.15s linear;
+  transition: opacity 0.15s linear;
+}
+
+.cfp-hotkeys-container.fade.in {
+  z-index: 10002;
+  visibility: visible;
+  opacity: 1;
+}
+
+.cfp-hotkeys-title {
+  font-weight: bold;
+  text-align: center;
+  font-size: 1.2em;
+}
+
+.cfp-hotkeys {
+  width: 100%;
+  height: 100%;
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.cfp-hotkeys table {
+  margin: auto;
+  color: #333;
+}
+
+.cfp-content {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.cfp-hotkeys-keys {
+  padding: 5px;
+  text-align: right;
+}
+
+.cfp-hotkeys-key {
+  display: inline-block;
+  color: #fff;
+  background-color: #333;
+  border: 1px solid #333;
+  border-radius: 5px;
+  text-align: center;
+  margin-right: 5px;
+  box-shadow: inset 0 1px 0 #666, 0 1px 0 #bbb;
+  padding: 5px 9px;
+  font-size: 1em;
+}
+
+.cfp-hotkeys-text {
+  padding-left: 10px;
+  font-size: 1em;
+}
+
+.cfp-hotkeys-close {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  font-size: 2em;
+  font-weight: bold;
+  padding: 5px 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  min-height: 45px;
+  min-width: 45px;
+  text-align: center;
+}
+
+.cfp-hotkeys-close:hover {
+  background-color: #fff;
+  cursor: pointer;
+}
+
+@media all and (max-width: 500px) {
+  .cfp-hotkeys {
+    font-size: 0.8em;
+  }
+}
+
+@media all and (min-width: 750px) {
+  .cfp-hotkeys {
+    font-size: 1.2em;
+  }
+}  `],
+  template: `<div class="cfp-hotkeys-container fade" [ngClass]="{'in': helpVisible}" style="display:none"><div class="cfp-hotkeys">
+  <h4 class="cfp-hotkeys-title">{{ title }}</h4>
+  <table><tbody>
+    <tr *ngFor="let hotkey of hotkeys">
+      <td class="cfp-hotkeys-keys">
+        <span *ngFor="let key of hotkey.formatted" class="cfp-hotkeys-key">{{ key }}</span>
+      </td>
+      <td class="cfp-hotkeys-text">{{ hotkey.description }}</td>
+    </tr>
+  </tbody></table>
+  <div class="cfp-hotkeys-close" (click)="toggleCheatSheet()">&#215;</div>
+</div></div>`,
+})
+export class CheatSheetComponent implements OnInit, OnDestroy {
+  helpVisible = false;
+  @Input() title: string = 'Keyboard Shortcuts:';
+  subscription: Subscription;
+
+  hotkeys: Hotkey[];
+
+  constructor(private hotkeysService: HotkeysService) { }
+
+  public ngOnInit(): void {
+    this.subscription = this.hotkeysService.cheatSheetToggle.subscribe(() => {
+      this.hotkeys = this.hotkeysService.hotkeys;
+      this.toggleCheatSheet();
+    })
+  }
+
+  public ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  public toggleCheatSheet(): void {
+    this.helpVisible = !this.helpVisible;
+  }
+}

--- a/src/directives/cheatsheet.component.ts
+++ b/src/directives/cheatsheet.component.ts
@@ -134,7 +134,7 @@ export class CheatSheetComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.subscription = this.hotkeysService.cheatSheetToggle.subscribe(() => {
-      this.hotkeys = this.hotkeysService.hotkeys;
+      this.hotkeys = this.hotkeysService.hotkeys.filter(hotkey => hotkey.description);
       this.toggleCheatSheet();
     })
   }

--- a/src/models/hotkey.options.ts
+++ b/src/models/hotkey.options.ts
@@ -1,0 +1,17 @@
+import { OpaqueToken } from '@angular/core';
+
+export interface IHotkeyOptions {
+  /**
+   * Disable the cheat sheet popover dialog? Default: false
+   */
+  disableCheatSheet?: boolean;
+  /**
+   * Key combination to trigger the cheat sheet. Default: '?'
+   */
+  cheatSheetHotkey?: string;
+  /**
+   * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'
+   */
+  cheatSheetDescription?: string;
+};
+export const HotkeyOptions = new OpaqueToken('HotkeyOptions');

--- a/src/services/hotkeys.service.ts
+++ b/src/services/hotkeys.service.ts
@@ -1,4 +1,6 @@
-import {Injectable} from '@angular/core';
+import { HotkeyOptions, IHotkeyOptions } from './../models/hotkey.options';
+import { Subject } from 'rxjs/Subject';
+import { Inject, Injectable } from '@angular/core';
 import {Hotkey} from '../models/hotkey.model';
 import 'mousetrap';
 
@@ -7,10 +9,11 @@ export class HotkeysService {
     hotkeys: Hotkey[] = [];
     pausedHotkeys: Hotkey[] = [];
     mousetrap: MousetrapInstance;
+    cheatSheetToggle: Subject<any> = new Subject();
 
     private _preventIn = ['INPUT', 'SELECT', 'TEXTAREA'];
 
-    constructor() {
+    constructor(@Inject(HotkeyOptions) private options: IHotkeyOptions) {
         Mousetrap.prototype.stopCallback = (event: KeyboardEvent, element: HTMLElement, combo: string, callback: Function) => {
             // if the element has the class "mousetrap" then no need to stop
             if((' ' + element.className + ' ').indexOf(' mousetrap ') > -1) {
@@ -19,6 +22,16 @@ export class HotkeysService {
             return (element.contentEditable && element.contentEditable == 'true');
         };
         this.mousetrap = new (<any>Mousetrap)();
+        if (!this.options.disableCheatSheet) {
+            this.add(new Hotkey(
+                this.options.cheatSheetHotkey || '?',
+                function(event: KeyboardEvent) {
+                    this.cheatSheetToggle.next({});
+                }.bind(this),
+                [],
+                this.options.cheatSheetDescription || 'Show / hide this help menu',
+            ))
+        }
     }
 
     add(hotkey: Hotkey | Hotkey[]): Hotkey | Hotkey[] {


### PR DESCRIPTION
I implemented a cheatsheet feature like [angular-hotkeys](http://chieffancypants.github.io/angular-hotkeys/).

The README.MD file explains the customization options.  Existing users would just need to add a `<hotkeys-cheatsheet></hotkeys-cheatsheet>` element to their top level template.