### PR TITLE
fix(npmignore) Ignore *.ts, but publish *.d.ts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,11 +5,10 @@ npm-debug.log
 # Angular
 /compiled
 
-# DO NOT IGNORE TYPESCRIPT FILES FOR NPM
+# DO NOT IGNORE COMPILED FILES FOR NPM
 # TypeScript
-# *.js
-# *.map
-# *.d.ts
+*.ts
+!*.d.ts
 
 # JetBrains
 .idea


### PR DESCRIPTION
Fixes #23 by not including *.ts files in the published npm repo.