### PR TITLE
fix(types): Remove @types/es6-shim requirement

### DIFF
--- a/src/hotkeys.directive.ts
+++ b/src/hotkeys.directive.ts
@@ -8,7 +8,7 @@ import 'mousetrap';
     providers : [HotkeysService]
 })
 export class HotkeysDirective implements OnInit, OnDestroy {
-    @Input() hotkeys: Array<{[combo: string]: (event: KeyboardEvent, combo: string) => ExtendedKeyboardEvent}>;
+    @Input() hotkeys: {[combo: string]: (event: KeyboardEvent, combo: string) => ExtendedKeyboardEvent}[];
 
     private mousetrap: MousetrapInstance;
     private hotkeysList: Hotkey[] = [];


### PR DESCRIPTION
A library of mine that uses angular2-hotkeys  can't compile because `hotkeys.directive.d.ts` includes a a reference to `es6-shim`.  Change `Array<blah>` to `blah[]` makes typescript not require the `es6-shim` types.

FYI, the problem is that `es6-shim` and `core-js` definitions both create types for the same objects and so they can't be included in the same project.  Angular has made the decision to go with `core-js`, so my libraries have all gone that route.