### PR TITLE
#39: Add option to close cheat sheet on ESC

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -80,6 +80,10 @@ export interface IHotkeyOptions {
    */
   cheatSheetHotkey?: string;
   /**
+       * Use also ESC for closing the cheat sheet. Default: false
+       */
+      cheatSheetCloseEsc?: boolean;
+  /**
    * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'
    */
   cheatSheetDescription?: string;

--- a/README.MD
+++ b/README.MD
@@ -80,9 +80,9 @@ export interface IHotkeyOptions {
    */
   cheatSheetHotkey?: string;
   /**
-       * Use also ESC for closing the cheat sheet. Default: false
-       */
-      cheatSheetCloseEsc?: boolean;
+   * Use also ESC for closing the cheat sheet. Default: false
+   */
+  cheatSheetCloseEsc?: boolean;
   /**
    * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'
    */

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
     "mousetrap": "^1.6.0"
   },
   "devDependencies": {
-    "@angular/common": "4.0.0-beta.6",
-    "@angular/compiler": "4.0.0-beta.6",
-    "@angular/compiler-cli": "4.0.0-beta.6",
-    "@angular/core": "4.0.0-beta.6",
-    "@types/core-js": "^0.9.35",
-    "codelyzer": "^0.0.28",
-    "rxjs": "^5.0.1",
+    "@angular/common": "4.2.5",
+    "@angular/compiler": "4.2.5",
+    "@angular/compiler-cli": "4.2.5",
+    "@angular/core": "4.2.5",
+    "@types/core-js": "0.9.41",
+    "codelyzer": "~3.0.1",
+    "rxjs": "^5.4.0",
     "tslint": "^3.15.1",
-    "typescript": "2.1.5",
-    "zone.js": "0.7.2"
+    "typescript": "~2.3.3",
+    "zone.js": "^0.8.4"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:AnBauer/angular2-hotkeys.git"
+    "url": "git@github.com:brtnshrdr/angular2-hotkeys.git"
   },
   "author": {
     "name": "Nick Richardson",
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "git@github.com:AnBauer/angular2-hotkeys.git/issues"
+    "url": "git@github.com:brtnshrdr/angular2-hotkeys.git/issues"
   },
   "main": "./index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:brtnshrdr/angular2-hotkeys.git"
+    "url": "git@github.com:AnBauer/angular2-hotkeys.git"
   },
   "author": {
     "name": "Nick Richardson",
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "git@github.com:brtnshrdr/angular2-hotkeys.git/issues"
+    "url": "git@github.com:AnBauer/angular2-hotkeys.git/issues"
   },
   "main": "./index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-hotkeys",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",

--- a/src/cheatsheet.component.ts
+++ b/src/cheatsheet.component.ts
@@ -134,9 +134,16 @@ export class CheatSheetComponent implements OnInit, OnDestroy {
     }
 
     public ngOnInit(): void {
-        this.subscription = this.hotkeysService.cheatSheetToggle.subscribe(() => {
-            this.hotkeys = this.hotkeysService.hotkeys.filter(hotkey => hotkey.description);
-            this.toggleCheatSheet();
+        this.subscription = this.hotkeysService.cheatSheetToggle.subscribe((isOpen) => {
+            if(isOpen !== false) {
+                this.hotkeys = this.hotkeysService.hotkeys.filter(hotkey => hotkey.description);
+            }
+
+            if(isOpen === false) {
+                this.helpVisible = false;
+            } else {
+                this.toggleCheatSheet();
+            }
         });
     }
 

--- a/src/hotkey.options.ts
+++ b/src/hotkey.options.ts
@@ -9,6 +9,11 @@ export interface IHotkeyOptions {
      * Key combination to trigger the cheat sheet. Default: '?'
      */
     cheatSheetHotkey?: string;
+
+    /**
+     * Use also ESC for closing the cheat sheet. Default: false
+     */
+    cheatSheetCloseEsc?: boolean;
     /**
      * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'
      */

--- a/src/hotkeys.service.ts
+++ b/src/hotkeys.service.ts
@@ -26,12 +26,24 @@ export class HotkeysService {
             this.add(new Hotkey(
                     this.options.cheatSheetHotkey || '?',
                     function (event: KeyboardEvent) {
-                        this.cheatSheetToggle.next({});
+                        this.cheatSheetToggle.next();
                     }.bind(this),
                     [],
                     this.options.cheatSheetDescription || 'Show / hide this help menu',
             ));
         }
+
+        if(this.options.cheatSheetCloseEsc) {
+            this.add(new Hotkey(
+                'esc',
+                function (event: KeyboardEvent) {
+                    this.cheatSheetToggle.next(false);
+                }.bind(this),
+                ['HOTKEYS-CHEATSHEET'],
+                'Hide this help menu',
+            ));
+        }
+
     }
 
     add(hotkey: Hotkey | Hotkey[], specificEvent?: string): Hotkey | Hotkey[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "lib": [
+      "es2016",
+      "dom"
+    ]
   },
   "angularCompilerOptions": {
     "genDir": "compiled"


### PR DESCRIPTION
update angular dependencies to 4.2.5 and fix tsconfig.

Minor optimization for updating the list of hotkeys.