### PR TITLE
Configuration for Esc-to-close cheat sheet help

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -69,10 +69,10 @@ The `HotkeysService` will automatically register the `?` key combo to toggle the
 an optional fourth parameter as a string or optionally as a function for dynamic descriptions.
 
 ```typescript
-    this._hotkeysService.add(new Hotkey('meta+shift+g', (event: KeyboardEvent): boolean => {
-        console.log('Secret message');
-        return false;
-    }, undefined, 'Send a secret message to the console.'));
+this._hotkeysService.add(new Hotkey('meta+shift+g', (event: KeyboardEvent): boolean => {
+    console.log('Secret message');
+    return false;
+}, undefined, 'Send a secret message to the console.'));
 ```
 
 The third parameter, given as `undefined`, can be used to allow the Hotkey to fire in INPUT, SELECT or TEXTAREA tags.
@@ -96,8 +96,8 @@ export interface IHotkeyOptions {
    */
   cheatSheetCloseEsc?: boolean;
   /**
-    * Description for the ESC key for closing the cheat sheet (if enabed). Default: 'Hide this help menu'
-    */
+   * Description for the ESC key for closing the cheat sheet (if enabed). Default: 'Hide this help menu'
+   */
   cheatSheetCloseEscDescription?: string;
   /**
    * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'

--- a/README.MD
+++ b/README.MD
@@ -65,6 +65,18 @@ Based off of the [angular-hotkeys library](https://github.com/chieffancypants/an
 To enable the cheat sheet, simply add `<hotkeys-cheatsheet></hotkeys-cheatsheet>` to your top level component template.
 The `HotkeysService` will automatically register the `?` key combo to toggle the cheat sheet.
 
+**NB!** Only hotkeys that have a description will apear on the cheat sheet. The Hotkey constructor takes a description as
+an optional fourth parameter as a string or optionally as a function for dynamic descriptions.
+
+```typescript
+    this._hotkeysService.add(new Hotkey('meta+shift+g', (event: KeyboardEvent): boolean => {
+        console.log('Secret message');
+        return false;
+    }, undefined, 'Send a secret message to the console.'));
+```
+
+The third parameter, given as `undefined`, can be used to allow the Hotkey to fire in INPUT, SELECT or TEXTAREA tags.
+
 ### Cheat Sheet Customization
 
 1. You can now pass in custom options in `HotkeysModule.forRoot(options: IHotkeyOptions)`.

--- a/README.MD
+++ b/README.MD
@@ -84,6 +84,10 @@ export interface IHotkeyOptions {
    */
   cheatSheetCloseEsc?: boolean;
   /**
+    * Description for the ESC key for closing the cheat sheet (if enabed). Default: 'Hide this help menu'
+    */
+  cheatSheetCloseEscDescription?: string;
+  /**
    * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'
    */
   cheatSheetDescription?: string;

--- a/src/hotkey.options.ts
+++ b/src/hotkey.options.ts
@@ -15,6 +15,10 @@ export interface IHotkeyOptions {
      */
     cheatSheetCloseEsc?: boolean;
     /**
+     * Description for the ESC key for closing the cheat sheet (if enabed). Default: 'Hide this help menu'
+     */
+    cheatSheetCloseEscDescription?: string;
+    /**
      * Description for the cheat sheet hot key in the cheat sheet. Default: 'Show / hide this help menu'
      */
     cheatSheetDescription?: string;

--- a/src/hotkeys.service.ts
+++ b/src/hotkeys.service.ts
@@ -40,7 +40,7 @@ export class HotkeysService {
                     this.cheatSheetToggle.next(false);
                 }.bind(this),
                 ['HOTKEYS-CHEATSHEET'],
-                'Hide this help menu',
+                this.options.cheatSheetCloseEscDescription || 'Hide this help menu',
             ));
         }
 


### PR DESCRIPTION
I added a new option to change the description for the Esc to close for the cheat sheet. Also updated the README.MD to reflect this new option.

Also added a small blurb to the README.MD about how to add descriptions to Hotkeys and that his is a prerequisite for having them show up in the cheat sheet.

This should address issues #50, #56, #64 as well as #63 