### PR TITLE
Bugfix/rxjs dependency

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,5 @@
 # angular2-hotkeys
-Angular 5.2.0+ and 6.0.0+ Compatible. Older versions might work but isn't officially tested.
+Angular 5.2.0+, 6 and 7 Compatible. Older versions might work but isn't officially tested.
 ## Installation
 
 To install this library, run:

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "angular2-hotkeys",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",
-    "prepublish": "tsc",
+    "prepublish": "tsc && ngc",
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
     "ngc": "./node_modules/.bin/ngc -p tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "@angular/core": "^5.2.0 || ^6.0.0",
-    "rxjs": "^5.5.0"
+    "rxjs": "^5.5.0 || ^6.0.0"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",
-    "prepublish": "tsc && ngc",
+    "prepare": "tsc && ngc",
     "tsc": "tsc",
     "tsc:watch": "tsc --watch",
     "ngc": "./node_modules/.bin/ngc -p tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-hotkeys",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "tsc && karma start",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "zone.js": "^0.8.4"
   },
   "peerDependencies": {
-    "@angular/core": "^5.2.0 || ^6.0.0",
+    "@angular/core": "^5.2.0 || ^6.0.0 || ^7.0.0",
     "rxjs": "^5.5.0 || ^6.0.0"
   },
   "engines": {


### PR DESCRIPTION
Bumps for Angular 7 and Rxjs peer dependencies.
Version bumped to 2.1.4

Closes #94, #85, #96 