### PR TITLE
Bug fixing: Get format for all sequences in combo array

### DIFF
--- a/src/hotkey.model.ts
+++ b/src/hotkey.model.ts
@@ -54,8 +54,8 @@ export class Hotkey {
 
     get formatted(): string[] {
         if(!this._formatted) {
-            let combo: string = this.combo[0];
-            let sequence: string[] = combo.split(/[\s]/);
+
+            let sequence: string[] = this.combo as Array<string>;
             for (let i = 0; i < sequence.length; i++) {
                 sequence[i] = Hotkey.symbolize(sequence[i]);
             }


### PR DESCRIPTION
In line 50 (first line of constructor) the this.combo variable is always set to array, due that in formatted() method it can use this variable as an array and set it directly to sequence variable.