### PR TITLE
More precise type for HotkeyModule.forRoot (for Ivy compatibility)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ export * from './src/hotkeys.service';
     declarations : [HotkeysDirective, CheatSheetComponent]
 })
 export class HotkeyModule {
-    static forRoot(options: IHotkeyOptions = {}): ModuleWithProviders {
+    static forRoot(options: IHotkeyOptions = {}): ModuleWithProviders<HotkeyModule> {
         return {
             ngModule : HotkeyModule,
             providers : [


### PR DESCRIPTION
This commit adds a generic to the ModuleWithProviders type used in HotkeyModule. This update is needed to ensure compatibility with Angular Ivy. More information can be found here: https://next.angular.io/guide/migration-module-with-providers#why-is-this-migration-necessary