### PR TITLE
Adopt to new mousetrap types

### DIFF
--- a/src/lib/hotkeys.service.ts
+++ b/src/lib/hotkeys.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Hotkey } from './hotkey.model';
 import { Subject } from 'rxjs';
 import { HotkeyOptions, IHotkeyOptions } from './hotkey.options';
-import 'mousetrap';
+import { MousetrapInstance } from 'mousetrap';
 
 @Injectable({
     providedIn: 'root'


### PR DESCRIPTION
With the new @types/1.6.4 angular2-hotkeys is broken. This should fix it.