### PR TITLE
Update MousetrapInstance Import

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
         "rxjs": "^5.5.0 || ^6.0.0"
     },
     "dependencies": {
-        "mousetrap": "^1.6.0",
-        "@types/mousetrap": "^1.6.0"
+        "@types/mousetrap": "^1.6.4",
+        "mousetrap": "^1.6.4"
     },
     "devDependencies": {
         "@angular-devkit/build-angular": "~0.900.3",

--- a/src/lib/hotkeys.directive.ts
+++ b/src/lib/hotkeys.directive.ts
@@ -1,7 +1,8 @@
 import { Directive, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
 import { ExtendedKeyboardEvent, Hotkey } from './hotkey.model';
 import { HotkeysService } from './hotkeys.service';
-import 'mousetrap';
+import { MousetrapInstance} from 'mousetrap';
+import * as Mousetrap from 'mousetrap';
 
 @Directive({
     selector: '[hotkeys]',

--- a/src/lib/hotkeys.service.ts
+++ b/src/lib/hotkeys.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Hotkey } from './hotkey.model';
 import { Subject } from 'rxjs';
 import { HotkeyOptions, IHotkeyOptions } from './hotkey.options';
-import 'mousetrap';
+import { MousetrapInstance} from 'mousetrap';
 
 @Injectable({
     providedIn: 'root'

--- a/src/lib/hotkeys.service.ts
+++ b/src/lib/hotkeys.service.ts
@@ -3,6 +3,7 @@ import { Hotkey } from './hotkey.model';
 import { Subject } from 'rxjs';
 import { HotkeyOptions, IHotkeyOptions } from './hotkey.options';
 import { MousetrapInstance} from 'mousetrap';
+import * as Mousetrap from 'mousetrap';
 
 @Injectable({
     providedIn: 'root'


### PR DESCRIPTION
Update MousetrapInstance import to fix compile error:
Cannot find name 'MousetrapInstance'.