### PR TITLE
Cannot find name 'MousetrapInstance' - issue fixed for angular v7

### DIFF
--- a/src/hotkeys.directive.ts
+++ b/src/hotkeys.directive.ts
@@ -1,7 +1,8 @@
 import {Directive, Input, OnInit, OnDestroy, ElementRef} from '@angular/core';
 import {Hotkey, ExtendedKeyboardEvent} from './hotkey.model';
 import {HotkeysService} from './hotkeys.service';
-import 'mousetrap';
+import {MousetrapInstance} from 'mousetrap';
+import * as Mousetrap from 'mousetrap';
 
 @Directive({
     selector : '[hotkeys]',

--- a/src/hotkeys.service.ts
+++ b/src/hotkeys.service.ts
@@ -2,7 +2,8 @@ import {HotkeyOptions, IHotkeyOptions} from './hotkey.options';
 import {Subject} from 'rxjs';
 import {Inject, Injectable} from '@angular/core';
 import {Hotkey} from './hotkey.model';
-import 'mousetrap';
+import {MousetrapInstance} from 'mousetrap';
+import * as Mousetrap from 'mousetrap';
 
 @Injectable()
 export class HotkeysService {


### PR DESCRIPTION
I have the below error in my **angular(v7.1.4)** project.

```
ERROR in src/app/app.module.ts(13,46): error TS2307: Cannot find module 'angular2-hotkeys'.
src/app/services/base/base.service.ts(6,40): error TS2307: Cannot find module 'angular2-hotkeys'.
```

So I add this pull request in angular2-hotkeys **v2.1.4** the last commit. If you have anything alternative way Kindly share me.