### PR TITLE
fix: made a copy to create formattedHotkey

### DIFF
--- a/src/lib/hotkey.model.ts
+++ b/src/lib/hotkey.model.ts
@@ -56,7 +56,7 @@ export class Hotkey {
     get formatted(): string[] {
         if (!this.formattedHotkey) {
 
-            const sequence: string[] = this.combo as Array<string>;
+            const sequence: string[] = [...this.combo] as Array<string>;
             for (let i = 0; i < sequence.length; i++) {
                 sequence[i] = Hotkey.symbolize(sequence[i]);
             }


### PR DESCRIPTION
Hi! There's a bug when we want to get a hotkey with a modifier. For example, the command "alt+s".
If we add this, it works as expected. But if I want to remove it, I need to get it before.
But it doesn't work because it's not "alt+s" anymore but "alt + s" (with spaces) because the combo have changed like the formatted. Same with the beautiful icon "⇧" instead of "shift".

Even if we can get around the problem by using the formatted combo in the "get" function, it's not normal.