### PR TITLE
REFACTOR: new (Mousetrap as any).default();

### DIFF
--- a/src/lib/hotkeys.service.ts
+++ b/src/lib/hotkeys.service.ts
@@ -25,7 +25,7 @@ export class HotkeysService {
             }
             return (element.contentEditable && element.contentEditable === 'true');
         };
-        this.mousetrap = new (Mousetrap as any).default();
+        this.mousetrap = new (Mousetrap)(document.documentElement);
         this.initCheatSheet();
     }
 


### PR DESCRIPTION
It fixes also the future implementation with the new angular browser - esbuild, at the moment if we try to migrate it throw an error about that.